### PR TITLE
Update DeepBoostedJet json to match the MXNet version.

### DIFF
--- a/DeepBoostedJet/V01/decorrelated/resnet-symbol.json
+++ b/DeepBoostedJet/V01/decorrelated/resnet-symbol.json
@@ -3156,5 +3156,5 @@
     299
   ], 
   "heads": [[244, 0, 0]], 
-  "attrs": {"mxnet_version": ["int", 10100]}
+  "attrs": {"mxnet_version": ["int", 10201]}
 }

--- a/DeepBoostedJet/V01/full/resnet-symbol.json
+++ b/DeepBoostedJet/V01/full/resnet-symbol.json
@@ -2586,5 +2586,5 @@
     272
   ], 
   "heads": [[222, 0, 0]], 
-  "attrs": {"mxnet_version": ["int", 10000]}
+  "attrs": {"mxnet_version": ["int", 10201]}
 }


### PR DESCRIPTION
This is intended to get rid of the printouts mentioned in https://github.com/cms-sw/cmssw/pull/23768#issuecomment-405913208. The content of the model is not changed.