### PR TITLE
Update DeepBoostedJet json version

### DIFF
--- a/DeepBoostedJet/V02/decorrelated/resnet-symbol.json
+++ b/DeepBoostedJet/V02/decorrelated/resnet-symbol.json
@@ -3312,5 +3312,5 @@
     303
   ], 
   "heads": [[245, 0, 0]], 
-  "attrs": {"mxnet_version": ["int", 10201]}
+  "attrs": {"mxnet_version": ["int", 10500]}
 }

--- a/DeepBoostedJet/V02/full/resnet-symbol.json
+++ b/DeepBoostedJet/V02/full/resnet-symbol.json
@@ -2586,5 +2586,5 @@
     272
   ], 
   "heads": [[222, 0, 0]], 
-  "attrs": {"mxnet_version": ["int", 10201]}
+  "attrs": {"mxnet_version": ["int", 10500]}
 }


### PR DESCRIPTION
Update json version to match the new MXNet 1.5.0 in CMSSW_11.
Addresses https://github.com/cms-data/RecoBTag-Combined/pull/16#issuecomment-525244876.